### PR TITLE
fix(swatch-renderer): Use `$.escapeSelector` in element selectors

### DIFF
--- a/view/base/web/js/swatch-renderer.js
+++ b/view/base/web/js/swatch-renderer.js
@@ -1116,7 +1116,7 @@ define([
         _EmulateSelected: function (selectedAttributes) {
             $.each(selectedAttributes, $.proxy(function (attributeCode, optionId) {
                 var elem = this.element.find('.' + this.options.classes.attributeClass +
-                    '[data-attribute-code="' + attributeCode + '"] [data-option-id="' + optionId + '"]'),
+                    '[data-attribute-code="' + $.escapeSelector(attributeCode) + '"] [data-option-id="' + $.escapeSelector(optionId) + '"]'),
                     parentInput = elem.parent();
 
                 if (elem.hasClass('selected')) {
@@ -1140,7 +1140,7 @@ define([
         _EmulateSelectedByAttributeId: function (selectedAttributes) {
             $.each(selectedAttributes, $.proxy(function (attributeId, optionId) {
                 var elem = this.element.find('.' + this.options.classes.attributeClass +
-                    '[data-attribute-id="' + attributeId + '"] [data-option-id="' + optionId + '"]'),
+                    '[data-attribute-id="' + $.escapeSelector(attributeId) + '"] [data-option-id="' + $.escapeSelector(optionId) + '"]'),
                     parentInput = elem.parent();
 
                 if (elem.hasClass('selected')) {


### PR DESCRIPTION
Otherwise, a URL like https://myshop.pl/tshirts?size=7%22 can result in a client-side error `Syntax error, unrecognized expression: .swatch-attribute[data-attribute-code="size"] [data-option-id="7""]` . This happens if the option ID includes a quotemark, which should be escaped before constructing a jQuery selector with it.